### PR TITLE
feat/pyda pmc

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for the DCO bot
+# https://github.com/probot/dco
+
+# Require all commits to be signed off EXCEPT for organization members and bots
+require:
+  members: false  # Organization members don't need to sign off

--- a/.github/workflows/stale-check.yml
+++ b/.github/workflows/stale-check.yml
@@ -1,0 +1,34 @@
+name: Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: "0 6 * * *"  # Daily at 6am UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    name: Mark stale issues and PRs
+    runs-on: linux-amd64-cpu4
+    permissions:
+      issues: write
+      pull-requests: write
+    timeout-minutes: 10
+    steps:
+      - uses: NVIDIA/dsx-github-actions/.github/actions/stale-check@d064e8779c341b8966dc811b2ae375c14b378738
+        # Refer to https://github.com/NVIDIA/dsx-github-actions/blob/main/docs/actions/stale-check.md for more details
+        with:
+          days-before-issue-stale: '60'
+          days-before-pr-stale: '30'
+          days-before-close: '7'
+          stale-issue-message: |
+            This issue has been inactive for 60 days and will be closed soon.
+            Please comment to keep it open.
+          stale-pr-message: |
+            This PR has been inactive for 30 days and will be closed soon.
+            Please push commits or comment to keep it open.
+          # Those labels are used to exempt issues and PRs from being marked or closed by the stale check
+          exempt-issue-labels: 'lifecycle/frozen,priority/critical,epic'
+          exempt-pr-labels: 'lifecycle/frozen,do-not-merge,wip'

--- a/src/ami.rs
+++ b/src/ami.rs
@@ -879,6 +879,10 @@ impl Redfish for Bmc {
     async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
         self.s.set_utc_timezone().await
     }
+
+    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
+        self.s.disable_psu_hot_spare().await
+    }
 }
 
 impl Bmc {

--- a/src/ami.rs
+++ b/src/ami.rs
@@ -825,10 +825,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/ami.rs
+++ b/src/ami.rs
@@ -517,7 +517,12 @@ impl Redfish for Bmc {
     }
 
     async fn boot_first(&self, target: Boot) -> Result<(), RedfishError> {
-        self.s.boot_first(target).await
+        let alias = match target {
+            Boot::Pxe => "Pxe",
+            Boot::HardDisk => "Hdd",
+            Boot::UefiHttp => "UefiHttp",
+        };
+        self.set_boot_order(alias).await
     }
 
     /// AMI BMC requires If-Match header for boot order changes
@@ -742,23 +747,7 @@ impl Redfish for Bmc {
         mac_address: &str,
     ) -> Result<Option<String>, RedfishError> {
         let mac = mac_address.to_uppercase();
-        let system = self.get_system().await?;
-
-        let boot_options_id =
-            system
-                .boot
-                .boot_options
-                .clone()
-                .ok_or_else(|| RedfishError::MissingKey {
-                    key: "boot.boot_options".to_string(),
-                    url: system.odata.odata_id.clone(),
-                })?;
-
-        let all_boot_options: Vec<BootOption> = self
-            .get_collection(boot_options_id)
-            .await
-            .and_then(|c| c.try_get::<BootOption>())?
-            .members;
+        let (system, all_boot_options) = self.get_system_and_boot_options().await?;
 
         let target = all_boot_options.iter().find(|opt| {
             let display = opt.display_name.to_uppercase();
@@ -971,6 +960,68 @@ impl Bmc {
         self.s.client.patch_with_if_match(&url, data).await
     }
 
+    async fn get_system_and_boot_options(
+        &self,
+    ) -> Result<(ComputerSystem, Vec<BootOption>), RedfishError> {
+        let system = self.get_system().await?;
+        let boot_options_id =
+            system
+                .boot
+                .boot_options
+                .clone()
+                .ok_or_else(|| RedfishError::MissingKey {
+                    key: "boot.boot_options".to_string(),
+                    url: system.odata.odata_id.clone(),
+                })?;
+        let all_boot_options: Vec<BootOption> = self
+            .get_collection(boot_options_id)
+            .await
+            .and_then(|c| c.try_get::<BootOption>())?
+            .members;
+        Ok((system, all_boot_options))
+    }
+
+    /// Finds the first boot option matching the given alias and moves it to the front
+    /// of the boot order.
+    async fn set_boot_order(&self, alias: &str) -> Result<(), RedfishError> {
+        let (system, all_boot_options) = self.get_system_and_boot_options().await?;
+
+        let target = all_boot_options
+            .iter()
+            .find(|opt| opt.alias.as_deref() == Some(alias));
+
+        let target_ref = target
+            .ok_or_else(|| {
+                let all_names: Vec<_> = all_boot_options
+                    .iter()
+                    .map(|b| {
+                        format!(
+                            "{}: {} (alias={})",
+                            b.boot_option_reference,
+                            b.display_name,
+                            b.alias.as_deref().unwrap_or("none")
+                        )
+                    })
+                    .collect();
+                RedfishError::MissingBootOption(format!(
+                    "No boot option with alias {:?} found; available: {:#?}",
+                    alias, all_names
+                ))
+            })?
+            .boot_option_reference
+            .clone();
+
+        let mut boot_order = system.boot.boot_order;
+
+        if boot_order.first() == Some(&target_ref) {
+            return Ok(());
+        }
+
+        boot_order.retain(|id| id != &target_ref);
+        boot_order.insert(0, target_ref);
+        self.change_boot_order(boot_order).await
+    }
+
     /// Get expected and actual first boot option for checking boot order setup.
     ///
     /// AMI boot option format example:
@@ -982,25 +1033,8 @@ impl Bmc {
         boot_interface_mac: &str,
     ) -> Result<(Option<String>, Option<String>), RedfishError> {
         let mac = boot_interface_mac.to_uppercase();
-        let system = self.get_system().await?;
+        let (system, all_boot_options) = self.get_system_and_boot_options().await?;
 
-        let boot_options_id =
-            system
-                .boot
-                .boot_options
-                .clone()
-                .ok_or_else(|| RedfishError::MissingKey {
-                    key: "boot.boot_options".to_string(),
-                    url: system.odata.odata_id.clone(),
-                })?;
-
-        let all_boot_options: Vec<BootOption> = self
-            .get_collection(boot_options_id)
-            .await
-            .and_then(|c| c.try_get::<BootOption>())?
-            .members;
-
-        // Find expected boot option display name (HTTP IPv4 with matching MAC)
         let expected_first_boot_option = all_boot_options
             .iter()
             .find(|opt| {

--- a/src/ami.rs
+++ b/src/ami.rs
@@ -293,6 +293,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<(), RedfishError> {
         self.setup_serial_console().await?;
         self.clear_tpm().await?;
@@ -942,9 +946,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/ami.rs
+++ b/src/ami.rs
@@ -1058,6 +1058,7 @@ impl Bmc {
         HashMap::from([
             ("VMXEN".to_string(), "Enable".into()), // VMX (Intel Virtualization)
             ("PCIS007".to_string(), "Enabled".into()), // SR-IOV Support
+            ("LEM0001".to_string(), 3.into()),      // PXE retry count (remove on future FW update)
             ("NWSK000".to_string(), "Enabled".into()), // Network Stack
             ("NWSK001".to_string(), "Disabled".into()), // IPv4 PXE Support
             ("NWSK006".to_string(), "Enabled".into()), // IPv4 HTTP Support

--- a/src/ami.rs
+++ b/src/ami.rs
@@ -24,12 +24,12 @@
 use std::{collections::HashMap, path::Path, time::Duration};
 
 use crate::{
+    jsonmap,
     model::{
         account_service::ManagerAccount,
         boot::{BootSourceOverrideEnabled, BootSourceOverrideTarget},
         certificate::Certificate,
         chassis::{Assembly, Chassis, NetworkAdapter},
-        storage::Drives,
         component_integrity::ComponentIntegrities,
         network_device_function::NetworkDeviceFunction,
         oem::nvidia_dpu::{HostPrivilegeLevel, NicMode},
@@ -39,16 +39,16 @@ use crate::{
         sensor::GPUSensors,
         service_root::{RedfishVendor, ServiceRoot},
         software_inventory::SoftwareInventory,
+        storage::Drives,
         task::Task,
         thermal::Thermal,
         update_service::{ComponentType, TransferProtocolType, UpdateService},
         BootOption, ComputerSystem, Manager, ManagerResetType,
     },
-    jsonmap,
     standard::RedfishStandard,
-    BiosProfileType, Boot, BootOptions, Collection, EnabledDisabled, JobState,
-    MachineSetupStatus, MachineSetupDiff, ODataId, PCIeDevice, PowerState, Redfish, RedfishError,
-    Resource, RoleId, Status, StatusInternal, SystemPowerControl,
+    BiosProfileType, Boot, BootOptions, Collection, EnabledDisabled, JobState, MachineSetupDiff,
+    MachineSetupStatus, ODataId, PCIeDevice, PowerState, Redfish, RedfishError, Resource, RoleId,
+    Status, StatusInternal, SystemPowerControl,
 };
 
 /// AMI uses BIOS attribute SETUP001 for Administrator Password (UEFI password)
@@ -378,14 +378,14 @@ impl Redfish for Bmc {
         use serde_json::Value;
 
         let attributes: HashMap<String, Value> = HashMap::from([
-            ("TER001".to_string(), "Enabled".into()),   // Console Redirection
-            ("TER010".to_string(), "Enabled".into()),   // Console Redirection EMS
-            ("TER06B".to_string(), "COM1".into()),      // Out-of-Band Mgmt Port
-            ("TER0021".to_string(), "115200".into()),   // Bits per second
-            ("TER0020".to_string(), "115200".into()),   // Bits per second EMS
+            ("TER001".to_string(), "Enabled".into()), // Console Redirection
+            ("TER010".to_string(), "Enabled".into()), // Console Redirection EMS
+            ("TER06B".to_string(), "COM1".into()),    // Out-of-Band Mgmt Port
+            ("TER0021".to_string(), "115200".into()), // Bits per second
+            ("TER0020".to_string(), "115200".into()), // Bits per second EMS
             ("TER012".to_string(), "VT100Plus".into()), // Terminal Type
-            ("TER011".to_string(), "VT-UTF8".into()),   // Terminal Type EMS
-            ("TER05D".to_string(), "None".into()),      // Flow Control
+            ("TER011".to_string(), "VT-UTF8".into()), // Terminal Type EMS
+            ("TER05D".to_string(), "None".into()),    // Flow Control
         ]);
 
         self.set_bios(attributes).await
@@ -540,10 +540,7 @@ impl Redfish for Bmc {
         }
 
         let body = HashMap::from([("Attributes", reset_attrs)]);
-        self.s
-            .client
-            .patch_with_if_match(&pending_url, body)
-            .await
+        self.s.client.patch_with_if_match(&pending_url, body).await
     }
 
     async fn get_network_device_functions(
@@ -786,8 +783,11 @@ impl Redfish for Bmc {
     }
 
     async fn enable_infinite_boot(&self) -> Result<(), RedfishError> {
-        self.set_bios(HashMap::from([("EndlessBoot".to_string(), "Enabled".into())]))
-            .await
+        self.set_bios(HashMap::from([(
+            "EndlessBoot".to_string(),
+            "Enabled".into(),
+        )]))
+        .await
     }
 
     async fn is_infinite_boot_enabled(&self) -> Result<Option<bool>, RedfishError> {
@@ -866,7 +866,10 @@ impl Redfish for Bmc {
         self.s.get_evidence(url).await
     }
 
-    async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
+    async fn set_host_privilege_level(
+        &self,
+        level: HostPrivilegeLevel,
+    ) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
 
@@ -945,16 +948,12 @@ impl Bmc {
             })
             .map(|opt| opt.display_name.clone());
 
-        let actual_first_boot_option = system
-            .boot
-            .boot_order
-            .first()
-            .and_then(|first_ref| {
-                all_boot_options
-                    .iter()
-                    .find(|opt| &opt.boot_option_reference == first_ref)
-                    .map(|opt| opt.display_name.clone())
-            });
+        let actual_first_boot_option = system.boot.boot_order.first().and_then(|first_ref| {
+            all_boot_options
+                .iter()
+                .find(|opt| &opt.boot_option_reference == first_ref)
+                .map(|opt| opt.display_name.clone())
+        });
 
         Ok((expected_first_boot_option, actual_first_boot_option))
     }
@@ -962,14 +961,14 @@ impl Bmc {
     /// Get the BIOS attributes for machine setup.
     fn machine_setup_attrs(&self) -> HashMap<String, serde_json::Value> {
         HashMap::from([
-            ("VMXEN".to_string(), "Enable".into()),        // VMX (Intel Virtualization)
-            ("PCIS007".to_string(), "Enabled".into()),     // SR-IOV Support
-            ("NWSK000".to_string(), "Enabled".into()),     // Network Stack
-            ("NWSK001".to_string(), "Disabled".into()),    // IPv4 PXE Support
-            ("NWSK006".to_string(), "Enabled".into()),     // IPv4 HTTP Support
-            ("NWSK002".to_string(), "Disabled".into()),    // IPv6 PXE Support
-            ("NWSK007".to_string(), "Disabled".into()),    // IPv6 HTTP Support
-            ("FBO001".to_string(), "UEFI".into()),         // Boot Mode Select
+            ("VMXEN".to_string(), "Enable".into()), // VMX (Intel Virtualization)
+            ("PCIS007".to_string(), "Enabled".into()), // SR-IOV Support
+            ("NWSK000".to_string(), "Enabled".into()), // Network Stack
+            ("NWSK001".to_string(), "Disabled".into()), // IPv4 PXE Support
+            ("NWSK006".to_string(), "Enabled".into()), // IPv4 HTTP Support
+            ("NWSK002".to_string(), "Disabled".into()), // IPv6 PXE Support
+            ("NWSK007".to_string(), "Disabled".into()), // IPv6 HTTP Support
+            ("FBO001".to_string(), "UEFI".into()),  // Boot Mode Select
             ("EndlessBoot".to_string(), "Enabled".into()), // Infinite Boot
         ])
     }
@@ -1002,7 +1001,10 @@ impl Bmc {
                 continue;
             };
             let act = actual.as_str().unwrap_or(&actual.to_string()).to_string();
-            let exp = expected.as_str().unwrap_or(&expected.to_string()).to_string();
+            let exp = expected
+                .as_str()
+                .unwrap_or(&expected.to_string())
+                .to_string();
             if act != exp {
                 diffs.push(MachineSetupDiff {
                     key: key.to_string(),

--- a/src/ami.rs
+++ b/src/ami.rs
@@ -62,6 +62,45 @@ impl Bmc {
     pub fn new(s: RedfishStandard) -> Result<Bmc, RedfishError> {
         Ok(Bmc { s })
     }
+
+    /// LenovoAMI-specific lockdown status via OEM ConfigBMC endpoint.
+    async fn lockdown_status_lenovo_ami(&self) -> Result<Status, RedfishError> {
+        const LOCKDOWN_FIELDS: &[&str] = &[
+            "LockoutHostControl",
+            "LockoutBiosVariableWriteMode",
+            "LockdownBiosSettingsChange",
+            "LockdownBiosUpgradeDowngrade",
+        ];
+
+        let (_status, body): (_, serde_json::Value) =
+            self.s.client.get("Managers/Self/Oem/ConfigBMC").await?;
+
+        let values: Vec<&str> = LOCKDOWN_FIELDS
+            .iter()
+            .map(|key| body.get(key).and_then(|v| v.as_str()).unwrap_or("unknown"))
+            .collect();
+
+        let message = LOCKDOWN_FIELDS
+            .iter()
+            .zip(&values)
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let is_locked = values.iter().all(|&v| v == "Enable");
+        let is_unlocked = values.iter().all(|&v| v == "Disable");
+
+        Ok(Status {
+            message,
+            status: if is_locked {
+                StatusInternal::Enabled
+            } else if is_unlocked {
+                StatusInternal::Disabled
+            } else {
+                StatusInternal::Partial
+            },
+        })
+    }
 }
 
 #[async_trait::async_trait]
@@ -314,23 +353,39 @@ impl Redfish for Bmc {
             .await
     }
 
-    /// AMI lockdown - controls KCS access, USB support, and Host Interface
+    /// AMI lockdown - controls KCS access, USB support, and Host Interface.
+    /// On LenovoAMI, uses the OEM ConfigBMC endpoint to control host lockout,
+    /// BIOS variable write, BIOS settings change, and BIOS upgrade/downgrade.
     async fn lockdown(&self, target: EnabledDisabled) -> Result<(), RedfishError> {
         use EnabledDisabled::*;
-        // (KCSACP, USB000, HostInterface enabled)
+        if self.s.vendor == Some(RedfishVendor::LenovoAMI) {
+            let value = match target {
+                Enabled => "Enable",
+                Disabled => "Disable",
+            };
+            let body = HashMap::from([
+                ("LockoutHostControl", value),
+                ("LockoutBiosVariableWriteMode", value),
+                ("LockdownBiosSettingsChange", value),
+                ("LockdownBiosUpgradeDowngrade", value),
+            ]);
+            return self
+                .s
+                .client
+                .post("Managers/Self/Oem/ConfigBMC", body)
+                .await
+                .map(|_| ());
+        }
+
         let (kcsacp, usb, hi_enabled) = match target {
             Enabled => ("Deny All", "Disabled", false),
             Disabled => ("Allow All", "Enabled", true),
         };
-
-        // Set BIOS attributes
         self.set_bios(HashMap::from([
             ("KCSACP".to_string(), kcsacp.into()),
             ("USB000".to_string(), usb.into()),
         ]))
         .await?;
-
-        // Set Host Interface
         let hi_body = HashMap::from([("InterfaceEnabled", hi_enabled)]);
         self.s
             .client
@@ -338,8 +393,13 @@ impl Redfish for Bmc {
             .await
     }
 
-    /// AMI lockdown_status - checks KCS access, USB support, and Host Interface
+    /// AMI lockdown status - checks KCS access, USB support, and Host Interface.
+    /// On LenovoAMI, reads the OEM ConfigBMC endpoint instead.
     async fn lockdown_status(&self) -> Result<Status, RedfishError> {
+        if self.s.vendor == Some(RedfishVendor::LenovoAMI) {
+            return self.lockdown_status_lenovo_ami().await;
+        }
+
         let bios = self.s.bios().await?;
         let url = format!("Systems/{}/Bios", self.s.system_id());
         let attrs = jsonmap::get_object(&bios, "Attributes", &url)?;

--- a/src/ami.rs
+++ b/src/ami.rs
@@ -297,12 +297,12 @@ impl Redfish for Bmc {
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         self.setup_serial_console().await?;
         self.clear_tpm().await?;
         let attrs = self.machine_setup_attrs();
         self.set_bios(attrs).await?;
-        Ok(())
+        Ok(None)
     }
 
     /// Check machine setup status for AMI BMC.

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -1303,7 +1303,8 @@ impl Bmc {
             redfish_settings_apply_time: apply_time,
             attributes: boot,
         };
-        let url = format!("Managers/{}/Attributes", self.s.manager_id());
+        let manager_id = self.s.manager_id();
+        let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
         self.s
             .client
             .patch(&url, set_boot)
@@ -1313,7 +1314,7 @@ impl Bmc {
 
     async fn set_idrac_lockdown(&self, enabled: EnabledDisabled) -> Result<(), RedfishError> {
         let manager_id: &str = self.s.manager_id();
-        let url = format!("Managers/{manager_id}/Attributes/");
+        let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
 
         let mut lockdown = HashMap::new();
         lockdown.insert("Lockdown.1.SystemLockdown", enabled.to_string());

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -1840,22 +1840,6 @@ impl Bmc {
         nic_slot: &str,
     ) -> Result<dell::MachineBiosAttrs, RedfishError> {
         let curr_bios_attributes = self.s.bios_attributes().await?;
-        let curr_enabled_boot_options = match curr_bios_attributes.get("SetBootOrderEn") {
-            Some(enabled_boot_options) => enabled_boot_options.as_str().unwrap_or_default(),
-            None => {
-                return Err(RedfishError::MissingKey {
-                    key: "SetBootOrderEn".to_owned(),
-                    url: format!("Systems/{}/Bios", self.s.system_id()),
-                });
-            }
-        };
-
-        // We want to disable all boot options other than HTTP Device 1.
-        let boot_options_to_disable_arr: Vec<&str> = curr_enabled_boot_options
-            .split(",")
-            .filter(|boot_option| *boot_option != "NIC.HttpDevice.1-1")
-            .collect();
-        let boot_options_to_disable_str = boot_options_to_disable_arr.join(",");
 
         // RedirAfterBoot: Not available in iDRAC 10
         let redir_after_boot = curr_bios_attributes
@@ -1911,7 +1895,9 @@ impl Bmc {
             http_device_1_interface: nic_slot.to_string(),
             set_boot_order_en: nic_slot.to_string(),
             http_device_1_tls_mode: dell::TlsMode::None,
-            set_boot_order_dis: boot_options_to_disable_str,
+            // We used to use this to disable all boot options other than the PXE boot option we wanted
+            // We found that it can cause the boot disk option to be disabled in the termination flow.
+            set_boot_order_dis: String::new(),
         })
     }
 

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -770,6 +770,9 @@ impl Redfish for Bmc {
             return Err(RedfishError::Lockdown);
         }
 
+        // clear any pending configs/jobs before changing the UEFI password
+        self.delete_job_queue().await?;
+
         self.s
             .change_bios_password(UEFI_PASSWORD_NAME, current_uefi_password, new_uefi_password)
             .await?;

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -2149,11 +2149,11 @@ impl Bmc {
         self.lifecycle_controller_is_ready().await?;
 
         let url: String = format!("Systems/System.Embedded.1/Storage/{controller_id}/Volumes");
-        let mut arg = HashMap::new();
-
-        arg.insert("Name", Value::String(volume_name.to_string()));
-        arg.insert("RAIDType", Value::String(raid_type.to_string()));
-        arg.insert("Drives", drive_info);
+        let arg = HashMap::from([
+            ("Name", Value::String(volume_name.to_string())),
+            ("RAIDType", Value::String(raid_type.to_string())),
+            ("Links", serde_json::json!({ "Drives": drive_info })),
+        ]);
 
         match self.s.client.post(&url, arg).await? {
             (_, Some(headers)) => self.parse_job_id_from_response_headers(&url, headers).await,

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -239,6 +239,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         selected_profile: BiosProfileType,
+        oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<(), RedfishError> {
         self.delete_job_queue().await?;
 
@@ -292,7 +296,22 @@ impl Redfish for Bmc {
             (_, None) => Err(RedfishError::NoHeader),
         }?;
 
-        self.machine_setup_oem().await?;
+        let oem_attrs = if let Some(dell) = oem_manager_profiles.get(&RedfishVendor::Dell) {
+            let model = crate::model_coerce(
+                self.get_system()
+                    .await?
+                    .model
+                    .unwrap_or_default()
+                    .as_str(),
+            );
+            dell.get(&model)
+                .and_then(|all| all.get(&selected_profile))
+                .cloned()
+                .unwrap_or_default()
+        } else {
+            HashMap::new()
+        };
+        self.machine_setup_oem(&oem_attrs).await?;
         self.setup_bmc_remote_access().await?;
 
         if has_dpu {
@@ -1102,18 +1121,6 @@ impl Redfish for Bmc {
         Ok(())
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        let manager_id = self.s.manager_id();
-        let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
-
-        let mut psu_attrs = HashMap::new();
-        psu_attrs.insert("ServerPwr.1.PSRapidOn", "Disabled");
-
-        let body = HashMap::from([("Attributes", psu_attrs)]);
-
-        self.s.client.patch(&url, body).await?;
-        Ok(())
-    }
 }
 
 impl Bmc {
@@ -1744,22 +1751,37 @@ impl Bmc {
     }
 
     /// Extra Dell-specific attributes we need to set that are not BIOS attributes
-    async fn machine_setup_oem(&self) -> Result<(), RedfishError> {
+    async fn machine_setup_oem(
+        &self,
+        extra_attrs: &HashMap<String, serde_json::Value>,
+    ) -> Result<(), RedfishError> {
         let manager_id = self.s.manager_id();
         let url = format!("Managers/{manager_id}/Oem/Dell/DellAttributes/{manager_id}");
 
         let current_attrs = self.manager_dell_oem_attributes().await?;
 
-        let mut attributes = HashMap::new();
+        let mut attributes: HashMap<String, serde_json::Value> = HashMap::new();
         // racadm set idrac.webserver.HostHeaderCheck 0
-        attributes.insert("WebServer.1.HostHeaderCheck", "Disabled".to_string());
+        attributes.insert(
+            "WebServer.1.HostHeaderCheck".to_string(),
+            serde_json::json!("Disabled"),
+        );
         // racadm set iDRAC.IPMILan.Enable 1
-        attributes.insert("IPMILan.1.Enable", "Enabled".to_string());
+        attributes.insert(
+            "IPMILan.1.Enable".to_string(),
+            serde_json::json!("Enabled"),
+        );
 
         // Only available in iDRAC 9
         if current_attrs.get("OS-BMC.1.AdminState").is_some() {
-            attributes.insert("OS-BMC.1.AdminState", "Disabled".to_string());
+            attributes.insert(
+                "OS-BMC.1.AdminState".to_string(),
+                serde_json::json!("Disabled"),
+            );
         }
+
+        // Merge config-driven OEM attributes (e.g. PSU Hot Spare settings)
+        attributes.extend(extra_attrs.clone());
 
         let body = HashMap::from([("Attributes", attributes)]);
         self.s.client.patch(&url, body).await?;
@@ -2273,5 +2295,76 @@ impl UpdateParameters {
             apply_time,
             oem: Empty {},
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    // Mirrors the attribute-merge logic in machine_setup_oem so we can test it
+    // without a live HTTP connection.
+    fn build_oem_attributes(
+        extra_attrs: &HashMap<String, serde_json::Value>,
+        has_os_bmc: bool,
+    ) -> HashMap<String, serde_json::Value> {
+        let mut attributes: HashMap<String, serde_json::Value> = HashMap::new();
+        attributes.insert(
+            "WebServer.1.HostHeaderCheck".to_string(),
+            serde_json::json!("Disabled"),
+        );
+        attributes.insert(
+            "IPMILan.1.Enable".to_string(),
+            serde_json::json!("Enabled"),
+        );
+        if has_os_bmc {
+            attributes.insert(
+                "OS-BMC.1.AdminState".to_string(),
+                serde_json::json!("Disabled"),
+            );
+        }
+        attributes.extend(extra_attrs.clone());
+        attributes
+    }
+
+    #[test]
+    fn test_machine_setup_oem_hardcoded_attrs_present() {
+        let extra: HashMap<String, serde_json::Value> = HashMap::new();
+        let attrs = build_oem_attributes(&extra, false);
+        assert_eq!(attrs["WebServer.1.HostHeaderCheck"], serde_json::json!("Disabled"));
+        assert_eq!(attrs["IPMILan.1.Enable"], serde_json::json!("Enabled"));
+        assert!(!attrs.contains_key("OS-BMC.1.AdminState"));
+    }
+
+    #[test]
+    fn test_machine_setup_oem_idrac9_attr_conditionally_added() {
+        let extra: HashMap<String, serde_json::Value> = HashMap::new();
+        let attrs = build_oem_attributes(&extra, true);
+        assert_eq!(attrs["OS-BMC.1.AdminState"], serde_json::json!("Disabled"));
+    }
+
+    #[test]
+    fn test_machine_setup_oem_extra_attrs_merged() {
+        let mut extra: HashMap<String, serde_json::Value> = HashMap::new();
+        extra.insert(
+            "System.1.psuHotSpare".to_string(),
+            serde_json::json!("Disabled"),
+        );
+        let attrs = build_oem_attributes(&extra, false);
+        assert_eq!(attrs["System.1.psuHotSpare"], serde_json::json!("Disabled"));
+        // Hardcoded attrs are still present
+        assert_eq!(attrs["WebServer.1.HostHeaderCheck"], serde_json::json!("Disabled"));
+    }
+
+    #[test]
+    fn test_machine_setup_oem_extra_attrs_override_hardcoded() {
+        // Ensure extra_attrs win over any hardcoded defaults if keys collide.
+        let mut extra: HashMap<String, serde_json::Value> = HashMap::new();
+        extra.insert(
+            "IPMILan.1.Enable".to_string(),
+            serde_json::json!("Disabled"),
+        );
+        let attrs = build_oem_attributes(&extra, false);
+        assert_eq!(attrs["IPMILan.1.Enable"], serde_json::json!("Disabled"));
     }
 }

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -1939,7 +1939,8 @@ impl Bmc {
                 target: "BIOS".to_string(),
             },
             import_buffer: format!(
-                r##"<SystemConfiguration><Component FQDD="BIOS.Setup.1-1"><!-- <Attribute Name="OldSysPassword"></Attribute>--><!-- <Attribute Name="NewSysPassword"></Attribute>--><Attribute Name="OldSetupPassword">{current_uefi_password}</Attribute><Attribute Name="NewSetupPassword"></Attribute></Component></SystemConfiguration>"##
+                r##"<SystemConfiguration><Component FQDD="BIOS.Setup.1-1"><!-- <Attribute Name="OldSysPassword"></Attribute>--><!-- <Attribute Name="NewSysPassword"></Attribute>--><Attribute Name="OldSetupPassword">{}</Attribute><Attribute Name="NewSetupPassword"></Attribute></Component></SystemConfiguration>"##,
+                XmlPcdata(current_uefi_password)
             ),
         };
 
@@ -2298,8 +2299,37 @@ impl UpdateParameters {
     }
 }
 
+// Escapes XML character data for element text content (PCDATA).
+// Use this for values inserted between tags, e.g. <x>value</x>.
+//
+// Do not use for XML attributes; attribute values require different escaping.
+struct XmlPcdata<'a>(&'a str);
+
+impl std::fmt::Display for XmlPcdata<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // XML: 2.4 Character Data and Markup
+        for c in self.0.chars() {
+            match c {
+                // The ampersand character (&) and the left angle
+                // bracket (<) MUST NOT appear in their literal form,
+                // except ... . If they are needed elsewhere, they
+                // MUST be escaped.
+                '&' => "&amp;".fmt(f)?,
+                '<' => "&lt;".fmt(f)?,
+                // The right angle bracket (>) may be represented
+                // using the string " &gt; ", and MUST, for
+                // compatibility, be escaped using ... "&gt;"
+                '>' => "&gt;".fmt(f)?,
+                _ => c.fmt(f)?,
+            }
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::XmlPcdata;
     use std::collections::HashMap;
 
     // Mirrors the attribute-merge logic in machine_setup_oem so we can test it
@@ -2366,5 +2396,32 @@ mod tests {
         );
         let attrs = build_oem_attributes(&extra, false);
         assert_eq!(attrs["IPMILan.1.Enable"], serde_json::json!("Disabled"));
+    }
+
+    #[test]
+    fn test_xml_pcdata_escapes_markup_chars() {
+        let input = r#"before & <tag> > after"#;
+        let escaped = XmlPcdata(input).to_string();
+        assert_eq!(escaped, "before &amp; &lt;tag&gt; &gt; after");
+    }
+
+    #[test]
+    fn test_xml_pcdata_leaves_plain_text_unchanged() {
+        let input = "abcXYZ123_- ";
+        let escaped = XmlPcdata(input).to_string();
+        assert_eq!(escaped, input);
+    }
+
+    #[test]
+    fn test_xml_pcdata_in_import_buffer_context() {
+        let password = r#"a&<b>c"#;
+        let xml = format!(
+            r##"<Attribute Name="OldSetupPassword">{}</Attribute>"##,
+            XmlPcdata(password)
+        );
+        assert_eq!(
+            xml,
+            r#"<Attribute Name="OldSetupPassword">a&amp;&lt;b&gt;c</Attribute>"#
+        );
     }
 }

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -2176,9 +2176,9 @@ impl Bmc {
     }
 
     async fn get_lifecycle_controller_status(&self) -> Result<String, RedfishError> {
+        let manager_id = self.s.manager_id();
         let url = format!(
-            "Dell/Managers/{}/DellLCService/Actions/DellLCService.GetRemoteServicesAPIStatus",
-            self.s.manager_id()
+            "Managers/{manager_id}/Oem/Dell/DellLCService/Actions/DellLCService.GetRemoteServicesAPIStatus"
         );
         let arg: HashMap<&'static str, Value> = HashMap::new();
         let (_status_code, resp_body, _resp_headers): (

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -243,7 +243,7 @@ impl Redfish for Bmc {
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         self.delete_job_queue().await?;
 
         let apply_time = dell::SetSettingsApplyTime {
@@ -291,10 +291,17 @@ impl Redfish for Bmc {
         }
 
         let url = format!("Systems/{}/Bios/Settings/", self.s.system_id());
-        match self.s.client.patch(&url, set_machine_attrs).await? {
-            (_, Some(headers)) => self.parse_job_id_from_response_headers(&url, headers).await,
-            (_, None) => Err(RedfishError::NoHeader),
-        }?;
+        let bios_job_id = match self.s.client.patch(&url, set_machine_attrs).await? {
+            (_, Some(headers)) => {
+                let jid = self
+                    .parse_job_id_from_response_headers(&url, headers)
+                    .await?;
+                Some(jid)
+            }
+            (_, None) => {
+                return Err(RedfishError::NoHeader);
+            }
+        };
 
         let oem_attrs = if let Some(dell) = oem_manager_profiles.get(&RedfishVendor::Dell) {
             let model = crate::model_coerce(
@@ -315,9 +322,8 @@ impl Redfish for Bmc {
         self.setup_bmc_remote_access().await?;
 
         if has_dpu {
-            Ok(())
+            Ok(bios_job_id)
         } else {
-            // Usually a missing DPU is an error, but for zero-dpu it isn't
             // Tell the caller and let them decide
             Err(RedfishError::NoDpu)
         }
@@ -1953,7 +1959,7 @@ impl Bmc {
         resp_headers: HeaderMap,
     ) -> Result<String, RedfishError> {
         let key = "location";
-        Ok(resp_headers
+        let jid = resp_headers
             .get(key)
             .ok_or_else(|| RedfishError::MissingKey {
                 key: key.to_string(),
@@ -1972,7 +1978,8 @@ impl Bmc {
                 field: key.to_string(),
                 err: InvalidValueError("unable to parse job_id from location string".to_string()),
             })?
-            .to_string())
+            .to_string();
+        Ok(jid)
     }
 
     /// import_system_configuration returns the job ID for importing this sytem configuration

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -881,10 +881,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -25,12 +25,34 @@ use std::{collections::HashMap, path::Path, time::Duration};
 use serde_json::Value;
 
 use crate::{
-    BiosProfileType, Boot, BootOptions, Collection, Deserialize, EnabledDisabled::{self, Disabled, Enabled}, JobState, MachineSetupDiff, MachineSetupStatus, OData, ODataId, PCIeDevice, PowerState, Redfish, RedfishError, Resource, RoleId, Serialize, Status, StatusInternal, SystemPowerControl, model::{
-        BootOption, ComputerSystem, Manager, Slot, SystemStatus, account_service::ManagerAccount, certificate::Certificate, chassis::{Assembly, Chassis, NetworkAdapter}, component_integrity::ComponentIntegrities, network_device_function::NetworkDeviceFunction, oem::{
+    model::{
+        account_service::ManagerAccount,
+        certificate::Certificate,
+        chassis::{Assembly, Chassis, NetworkAdapter},
+        component_integrity::ComponentIntegrities,
+        network_device_function::NetworkDeviceFunction,
+        oem::{
             hpe::{self, BootDevices},
             nvidia_dpu::{HostPrivilegeLevel, NicMode},
-        }, power::Power, secure_boot::SecureBoot, sel::{LogEntry, LogEntryCollection}, sensor::GPUSensors, service_root::{RedfishVendor, ServiceRoot}, software_inventory::SoftwareInventory, storage::{self, Drives}, task::Task, thermal::Thermal, update_service::{ComponentType, TransferProtocolType, UpdateService}
-    }, network::REDFISH_ENDPOINT, standard::RedfishStandard
+        },
+        power::Power,
+        secure_boot::SecureBoot,
+        sel::{LogEntry, LogEntryCollection},
+        sensor::GPUSensors,
+        service_root::{RedfishVendor, ServiceRoot},
+        software_inventory::SoftwareInventory,
+        storage::{self, Drives},
+        task::Task,
+        thermal::Thermal,
+        update_service::{ComponentType, TransferProtocolType, UpdateService},
+        BootOption, ComputerSystem, Manager, Slot, SystemStatus,
+    },
+    network::REDFISH_ENDPOINT,
+    standard::RedfishStandard,
+    BiosProfileType, Boot, BootOptions, Collection, Deserialize,
+    EnabledDisabled::{self, Disabled, Enabled},
+    JobState, MachineSetupDiff, MachineSetupStatus, OData, ODataId, PCIeDevice, PowerState,
+    Redfish, RedfishError, Resource, RoleId, Serialize, Status, StatusInternal, SystemPowerControl,
 };
 
 // The following is specific for the HPE machine since the HPE redfish
@@ -913,12 +935,19 @@ impl Redfish for Bmc {
         self.s.get_evidence(url).await
     }
 
-    async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
+    async fn set_host_privilege_level(
+        &self,
+        level: HostPrivilegeLevel,
+    ) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
 
     async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
         self.s.set_utc_timezone().await
+    }
+
+    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
+        self.s.disable_psu_hot_spare().await
     }
 }
 
@@ -1120,7 +1149,9 @@ impl Bmc {
             Err(RedfishError::MissingKey {
                 key: format!(
                     "{}/{}/{}",
-                    INTEL_ENABLE_VIRTUALIZATION_KEY, AMD_ENABLE_VIRTUALIZATION_KEY, PROC_VIRTUALIZATION_KEY
+                    INTEL_ENABLE_VIRTUALIZATION_KEY,
+                    AMD_ENABLE_VIRTUALIZATION_KEY,
+                    PROC_VIRTUALIZATION_KEY
                 )
                 .to_string(),
                 url: format!("Systems/{}/Bios", self.s.system_id()),

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -251,6 +251,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<(), RedfishError> {
         self.setup_serial_console().await?;
         self.clear_tpm().await?;
@@ -945,9 +949,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -255,12 +255,13 @@ impl Redfish for Bmc {
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         self.setup_serial_console().await?;
         self.clear_tpm().await?;
         self.set_virt_enable().await?;
         self.set_uefi_nic_boot().await?;
-        self.set_boot_order(BootDevices::Pxe).await
+        self.set_boot_order(BootDevices::Pxe).await?;
+        Ok(None)
     }
 
     async fn machine_setup_status(

--- a/src/lenovo.rs
+++ b/src/lenovo.rs
@@ -935,10 +935,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/lenovo.rs
+++ b/src/lenovo.rs
@@ -231,7 +231,27 @@ impl Redfish for Bmc {
     ) -> Result<(), RedfishError> {
         self.setup_serial_console().await?;
         self.clear_tpm().await?;
-        self.boot_first(Boot::Pxe).await?;
+        match self.boot_first(Boot::Pxe).await {
+            Ok(()) => {}
+            Err(RedfishError::MissingBootOption(_)) => {
+                tracing::info!(
+                    "Network boot option not found, setting it via OEM general boot order"
+                );
+                match self.set_general_boot_order_network_first().await {
+                    Ok(()) => {}
+                    Err(RedfishError::HTTPErrorCode {
+                        status_code: StatusCode::NOT_FOUND,
+                        ..
+                    }) => {
+                        tracing::info!(
+                            "OEM BootOrder.BootOrder not found, skipping (newer firmware)"
+                        );
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+            Err(e) => return Err(e),
+        }
         self.set_virt_enable().await?;
         self.set_uefi_boot_only().await?;
         if let Some(lenovo) = bios_profiles.get(&RedfishVendor::Lenovo) {
@@ -1726,6 +1746,40 @@ impl Bmc {
         })
     }
 
+    /// Set "Network" as the first entry in the OEM Lenovo general boot order
+    /// (`BootOrder.BootOrder`). This must happen before setting the DPU-first
+    /// network boot order, because the network boot options list is empty
+    /// when "Network" is not already present in the general boot order.
+    async fn set_general_boot_order_network_first(&self) -> Result<(), RedfishError> {
+        let url = format!("{}/BootOrder.BootOrder", self.get_boot_settings_uri());
+        let (_status_code, mut boot_order): (_, LenovoBootOrder) =
+            self.s.client.get(&url).await?;
+        const NETWORK: &str = "Network";
+
+        if let Some(pos) = boot_order
+            .boot_order_next
+            .iter()
+            .position(|s| s == NETWORK)
+        {
+            if pos == 0 {
+                tracing::info!("NO-OP: Network is already the first general boot option");
+                return Ok(());
+            }
+            boot_order.boot_order_next.swap(0, pos);
+        } else {
+            boot_order
+                .boot_order_next
+                .insert(0, NETWORK.to_string());
+        }
+
+        let body = HashMap::from([("BootOrderNext", boot_order.boot_order_next)]);
+        self.s
+            .client
+            .patch(&url, body)
+            .await
+            .map(|_status_code| ())
+    }
+    
     async fn get_expected_and_actual_first_boot_option(
         &self,
         boot_interface_mac: &str,

--- a/src/lenovo.rs
+++ b/src/lenovo.rs
@@ -224,6 +224,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<(), RedfishError> {
         self.setup_serial_console().await?;
         self.clear_tpm().await?;
@@ -1010,9 +1014,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/lenovo.rs
+++ b/src/lenovo.rs
@@ -228,7 +228,7 @@ impl Redfish for Bmc {
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         self.setup_serial_console().await?;
         self.clear_tpm().await?;
         match self.boot_first(Boot::Pxe).await {
@@ -270,7 +270,7 @@ impl Redfish for Bmc {
             }
         }
 
-        Ok(())
+        Ok(None)
     }
 
     async fn machine_setup_status(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -510,7 +510,6 @@ pub trait Redfish: Send + Sync + 'static {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError>;
 
     fn ac_powercycle_supported_by_power(&self) -> bool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,13 +549,29 @@ pub trait Redfish: Send + Sync + 'static {
         url: &str,
     ) -> Result<model::component_integrity::Evidence, RedfishError>;
 
-     // Sets the host privilege level for a DPU
-     async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError>;
+    // Sets the host privilege level for a DPU
+    async fn set_host_privilege_level(&self, level: HostPrivilegeLevel)
+        -> Result<(), RedfishError>;
 
-     // Sets the timezone to UTC
-     // Only applicable to Dells
-     async fn set_utc_timezone(&self) -> Result<(), RedfishError>;
+    // Sets the timezone to UTC
+    // Only applicable to Dells
+    async fn set_utc_timezone(&self) -> Result<(), RedfishError>;
 
+    /// Disables PSU Hot Spare mode on Dell PowerEdge servers.
+    ///
+    /// This ensures even power distribution across all PSUs instead of
+    /// prioritizing 2 of 4 PSUs in Hot Spare mode.
+    ///
+    /// Specifically sets Dell iDRAC attribute: `ServerPwr.1.PSRapidOn = "Disabled"`
+    ///
+    /// # Returns
+    /// - `Ok(())` if successfully disabled (Dell only)
+    /// - `Err(RedfishError::NotSupported)` for non-Dell vendors
+    /// - `Err(RedfishError)` if the PATCH operation fails
+    ///
+    /// # Note
+    /// Only applicable to Dell servers. Other vendors return `NotSupported`.
+    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError>;
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,7 @@ pub trait Redfish: Send + Sync + 'static {
         boot_interface_mac: Option<&str>,
         bios_profiles: &BiosProfileVendor,
         selected_profile: BiosProfileType,
+        oem_manager_profiles: &BiosProfileVendor,
     ) -> Result<(), RedfishError>;
 
     /// Is everything that machine_setup does already done?
@@ -556,21 +557,6 @@ pub trait Redfish: Send + Sync + 'static {
     // Only applicable to Dells
     async fn set_utc_timezone(&self) -> Result<(), RedfishError>;
 
-    /// Disables PSU Hot Spare mode on Dell PowerEdge servers.
-    ///
-    /// This ensures even power distribution across all PSUs instead of
-    /// prioritizing 2 of 4 PSUs in Hot Spare mode.
-    ///
-    /// Specifically sets Dell iDRAC attribute: `ServerPwr.1.PSRapidOn = "Disabled"`
-    ///
-    /// # Returns
-    /// - `Ok(())` if successfully disabled (Dell only)
-    /// - `Err(RedfishError::NotSupported)` for non-Dell vendors
-    /// - `Err(RedfishError)` if the PATCH operation fails
-    ///
-    /// # Note
-    /// Only applicable to Dell servers. Other vendors return `NotSupported`.
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError>;
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,13 +207,15 @@ pub trait Redfish: Send + Sync + 'static {
     /// bios_profiles: Map of vendor/model (with spaces replaced by underscores)/profile/type
     ///   to extra settings; expected to come from config rather than hardcoded.
     /// selected_profile: Profile to use (if present)
+    /// Returns Ok(Some(job_id)) when the vendor creates a job for the BIOS PATCH (e.g. Dell);
+    /// Ok(None) when no job is created. Caller should wait for job completion before configuring boot order.
     async fn machine_setup(
         &self,
         boot_interface_mac: Option<&str>,
         bios_profiles: &BiosProfileVendor,
         selected_profile: BiosProfileType,
         oem_manager_profiles: &BiosProfileVendor,
-    ) -> Result<(), RedfishError>;
+    ) -> Result<Option<String>, RedfishError>;
 
     /// Is everything that machine_setup does already done?
     async fn machine_setup_status(

--- a/src/liteon_powershelf.rs
+++ b/src/liteon_powershelf.rs
@@ -632,10 +632,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/liteon_powershelf.rs
+++ b/src/liteon_powershelf.rs
@@ -4,6 +4,8 @@ use std::{collections::HashMap, path::Path, time::Duration};
 use tokio::fs::File;
 
 use crate::model::account_service::ManagerAccount;
+use crate::model::certificate::Certificate;
+use crate::model::component_integrity::ComponentIntegrities;
 use crate::model::oem::nvidia_dpu::{HostPrivilegeLevel, NicMode};
 use crate::model::power::{Power, PowerSupplies, PowerSupply, Voltages};
 use crate::model::sensor::{GPUSensors, Sensor, Sensors};
@@ -22,8 +24,6 @@ use crate::{
     BiosProfileType, Collection, NetworkDeviceFunction, ODataId, Redfish, RedfishError, Resource,
 };
 use crate::{EnabledDisabled, JobState, MachineSetupStatus, RoleId};
-use crate::model::certificate::Certificate;
-use crate::model::component_integrity::ComponentIntegrities;
 
 const UEFI_PASSWORD_NAME: &str = "AdminPassword";
 
@@ -644,30 +644,22 @@ impl Redfish for Bmc {
         _database_id: &str,
         _certificate_id: &str,
     ) -> Result<Certificate, RedfishError> {
-        Err(RedfishError::NotSupported(
-            "not supported".to_string(),
-        ))
+        Err(RedfishError::NotSupported("not supported".to_string()))
     }
 
     async fn get_secure_boot_certificates(
         &self,
         _database_id: &str,
     ) -> Result<Vec<String>, RedfishError> {
-        Err(RedfishError::NotSupported(
-            "not supported".to_string(),
-        ))
+        Err(RedfishError::NotSupported("not supported".to_string()))
     }
 
     async fn is_bios_setup(&self, _boot_interface_mac: Option<&str>) -> Result<bool, RedfishError> {
-        Err(RedfishError::NotSupported(
-            "not supported".to_string(),
-        ))
+        Err(RedfishError::NotSupported("not supported".to_string()))
     }
 
     async fn enable_infinite_boot(&self) -> Result<(), RedfishError> {
-        Err(RedfishError::NotSupported(
-            "not supported".to_string(),
-        ))
+        Err(RedfishError::NotSupported("not supported".to_string()))
     }
 
     async fn trigger_evidence_collection(
@@ -675,42 +667,32 @@ impl Redfish for Bmc {
         _url: &str,
         _nonce: &str,
     ) -> Result<Task, RedfishError> {
-        Err(RedfishError::NotSupported(
-            "not supported".to_string(),
-        ))
+        Err(RedfishError::NotSupported("not supported".to_string()))
     }
 
     async fn get_evidence(
         &self,
         _url: &str,
     ) -> Result<crate::model::component_integrity::Evidence, RedfishError> {
-        Err(RedfishError::NotSupported(
-            "not supported".to_string(),
-        ))
+        Err(RedfishError::NotSupported("not supported".to_string()))
     }
 
     async fn get_firmware_for_component(
         &self,
         _component_integrity_id: &str,
     ) -> Result<crate::model::software_inventory::SoftwareInventory, RedfishError> {
-        Err(RedfishError::NotSupported(
-            "not supported".to_string(),
-        ))
+        Err(RedfishError::NotSupported("not supported".to_string()))
     }
 
     async fn get_component_ca_certificate(
         &self,
         _url: &str,
     ) -> Result<crate::model::component_integrity::CaCertificate, RedfishError> {
-        Err(RedfishError::NotSupported(
-            "not supported".to_string(),
-        ))
+        Err(RedfishError::NotSupported("not supported".to_string()))
     }
 
     async fn get_chassis_assembly(&self, _chassis_id: &str) -> Result<Assembly, RedfishError> {
-        Err(RedfishError::NotSupported(
-            "not supported".to_string(),
-        ))
+        Err(RedfishError::NotSupported("not supported".to_string()))
     }
 
     fn ac_powercycle_supported_by_power(&self) -> bool {
@@ -718,23 +700,26 @@ impl Redfish for Bmc {
     }
 
     async fn is_boot_order_setup(&self, _mac_address: &str) -> Result<bool, RedfishError> {
-        Err(RedfishError::NotSupported(
-            "not supported".to_string(),
-        ))
+        Err(RedfishError::NotSupported("not supported".to_string()))
     }
 
     async fn get_component_integrities(&self) -> Result<ComponentIntegrities, RedfishError> {
-        Err(RedfishError::NotSupported(
-            "not supported".to_string(),
-        ))
+        Err(RedfishError::NotSupported("not supported".to_string()))
     }
 
-    async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
+    async fn set_host_privilege_level(
+        &self,
+        level: HostPrivilegeLevel,
+    ) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
 
     async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
         self.s.set_utc_timezone().await
+    }
+
+    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
+        self.s.disable_psu_hot_spare().await
     }
 }
 

--- a/src/liteon_powershelf.rs
+++ b/src/liteon_powershelf.rs
@@ -187,6 +187,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<(), RedfishError> {
         // we don't do any changes for powershelves
         Ok(())
@@ -717,9 +721,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/liteon_powershelf.rs
+++ b/src/liteon_powershelf.rs
@@ -93,7 +93,8 @@ impl Redfish for Bmc {
     }
 
     async fn get_power_state(&self) -> Result<crate::PowerState, RedfishError> {
-        self.s.get_power_state().await
+        let system = self.get_system().await?;
+        Ok(system.power_state)
     }
 
     async fn get_power_metrics(&self) -> Result<crate::Power, RedfishError> {
@@ -360,7 +361,10 @@ impl Redfish for Bmc {
     }
 
     async fn get_system(&self) -> Result<ComputerSystem, RedfishError> {
-        self.s.get_system().await
+        let mut system = self.s.get_system().await?;
+        let power = self.get_power_metrics().await;
+        system.power_state = power_state_from_psus(&power);
+        Ok(system)
     }
 
     async fn get_secure_boot(&self) -> Result<crate::model::secure_boot::SecureBoot, RedfishError> {
@@ -734,5 +738,33 @@ impl Bmc {
             self.s.client.get(&url).await?;
         let log_entries = log_entry_collection.members;
         Ok(log_entries)
+    }
+}
+
+/// Derives the overall powershelf `PowerState` from individual PSU states.
+/// All On → On, all Off → Off, mixed or no PSUs or fetch failure → Unknown.
+fn power_state_from_psus(power: &Result<Power, RedfishError>) -> crate::PowerState {
+    let supplies = match power {
+        Ok(p) => p.power_supplies.as_deref().unwrap_or_default(),
+        Err(_) => return crate::PowerState::Unknown,
+    };
+
+    if supplies.is_empty() {
+        return crate::PowerState::Unknown;
+    }
+
+    let all_on = supplies
+        .iter()
+        .all(|ps| ps.power_state == Some(crate::PowerState::On));
+    let all_off = supplies
+        .iter()
+        .all(|ps| ps.power_state == Some(crate::PowerState::Off));
+
+    if all_on {
+        crate::PowerState::On
+    } else if all_off {
+        crate::PowerState::Off
+    } else {
+        crate::PowerState::Unknown
     }
 }

--- a/src/liteon_powershelf.rs
+++ b/src/liteon_powershelf.rs
@@ -192,9 +192,9 @@ impl Redfish for Bmc {
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         // we don't do any changes for powershelves
-        Ok(())
+        Ok(None)
     }
 
     async fn machine_setup_status(

--- a/src/model/chassis.rs
+++ b/src/model/chassis.rs
@@ -26,7 +26,7 @@ use tracing::debug;
 
 use super::oem::ChassisExtensions;
 use super::resource::OData;
-use super::{ODataId, ODataLinks, OnOff, PCIeFunction, ResourceStatus};
+use super::{ODataId, ODataLinks, PCIeFunction, PowerState, ResourceStatus};
 use crate::NetworkDeviceFunction;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -117,7 +117,7 @@ pub struct Chassis {
     pub part_number: Option<String>,
     pub power: Option<ODataId>,
     #[serde(default)] // Viking returns Chassis w.o power_state, so default will be used
-    pub power_state: Option<OnOff>,
+    pub power_state: Option<PowerState>,
     pub power_subsystem: Option<ODataId>,
     pub sensors: Option<ODataId>,
     pub serial_number: Option<String>,

--- a/src/model/ethernet_interface.rs
+++ b/src/model/ethernet_interface.rs
@@ -20,9 +20,19 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use super::{LinkStatus, ODataId, ODataLinks, ResourceStatus};
+
+/// Deserializes a JSON array that may contain null entries into a Vec<String>,
+/// filtering out the nulls. AMI BMCs return e.g. `"StaticNameServers": [null, null, null]`.
+fn deserialize_nullable_string_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let v: Vec<Option<String>> = Vec::deserialize(deserializer)?;
+    Ok(v.into_iter().flatten().collect())
+}
 
 /// http://redfish.dmtf.org/schemas/v1/EthernetInterface.v1_6_0.json
 /// The EthernetInterface schema contains an inventory of Ethernet interface components.
@@ -60,10 +70,10 @@ pub struct EthernetInterface {
     #[serde(rename = "MTUSize")]
     pub mtu_size: Option<i32>,
     pub name: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string_vec")]
     pub name_servers: Vec<String>,
     pub speed_mbps: Option<i32>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string_vec")]
     pub static_name_servers: Vec<String>,
     pub status: Option<ResourceStatus>,
     #[serde(rename = "VLANs")]

--- a/src/model/manager.rs
+++ b/src/model/manager.rs
@@ -170,7 +170,7 @@ mod test {
 
         let manager: super::Manager = serde_json::from_str(json_data).unwrap();
         assert!(manager.date_time.is_some());
-        
+
         let dt = manager.date_time.unwrap();
         // Input: 2025-12-05T21:07:58-06:00
         // UTC:   2025-12-06T03:07:58+00:00 (21:07 + 6 hours = 03:07 next day)
@@ -180,7 +180,7 @@ mod test {
         assert_eq!(dt.hour(), 3); // 21 + 6 = 27 -> 3 (next day)
         assert_eq!(dt.minute(), 7);
         assert_eq!(dt.second(), 58);
-        
+
         // Verify the datetime is converted to UTC format
         let dt_str = dt.to_rfc3339();
         assert_eq!(dt_str, "2025-12-06T03:07:58+00:00");

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -402,6 +402,8 @@ pub enum ResourceState {
     Updating,
     Qualified,
     Unknown,
+    // Lite-On powershelf PSUs report "Sleep" when powered off
+    Sleep,
 }
 
 impl fmt::Display for ResourceState {

--- a/src/model/oem/dell.rs
+++ b/src/model/oem/dell.rs
@@ -304,11 +304,11 @@ pub struct SetBiosSerialAttrs {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub enum SerialCommSettings {
-    OnConRedir,      // iDRAC 9 - preferred
+    OnConRedir, // iDRAC 9 - preferred
     OnNoConRedir,
-    OnConRedirAuto,  // newer iDRAC - preferred
-    OnConRedirCom1,  // newer iDRAC
-    OnConRedirCom2,  // newer iDRAC
+    OnConRedirAuto, // newer iDRAC - preferred
+    OnConRedirCom1, // newer iDRAC
+    OnConRedirCom2, // newer iDRAC
     Off,
 }
 
@@ -337,10 +337,10 @@ impl FromStr for SerialCommSettings {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub enum SerialPortSettings {
-    Com1,                    // legacy preferred
-    Com2,                    // legacy
-    Serial1Com1Serial2Com2,  // newer BIOS: SD1=COM1, SD2=COM2
-    Serial1Com2Serial2Com1,  // newer BIOS: SD1=COM2, SD2=COM1 (preferred for SOL)
+    Com1,                   // legacy preferred
+    Com2,                   // legacy
+    Serial1Com1Serial2Com2, // newer BIOS: SD1=COM1, SD2=COM2
+    Serial1Com2Serial2Com1, // newer BIOS: SD1=COM2, SD2=COM1 (preferred for SOL)
 }
 
 impl fmt::Display for SerialPortSettings {

--- a/src/model/oem/nvidia_viking.rs
+++ b/src/model/oem/nvidia_viking.rs
@@ -27,6 +27,9 @@ pub const DEFAULT_NVIDIA_INFINITEBOOT: EnableDisable = EnableDisable::Enable;
 pub const DEFAULT_KCS_INTERFACE_DISABLE: &str = KCS_INTERFACE_DISABLE_DENY_ALL;
 pub const KCS_INTERFACE_DISABLE_DENY_ALL: &str = "Deny All";
 pub const KCS_INTERFACE_DISABLE_ALLOW_ALL: &str = "Allow All";
+// Newer firmware uses "Enabled"/"Disabled" instead of "Deny All"/"Allow All"
+pub const KCS_INTERFACE_DISABLE_DISABLED: &str = "Disabled";
+pub const KCS_INTERFACE_DISABLE_ENABLED: &str = "Enabled";
 pub const RECOMMENDED_BIOS_VERSION: &str = "01.05.03";
 pub const MINIMUM_BIOS_VERSION: &str = "1.01.03";
 pub const RECOMMENDED_BMC_FW_VERSION: &str = "24.09.17";

--- a/src/model/power.rs
+++ b/src/model/power.rs
@@ -21,7 +21,54 @@
  */
 use super::{LinkType, ODataId, ODataLinks, ResourceStatus, StatusVec};
 use crate::model::sensor::Sensor;
+use crate::model::system::PowerState;
 use serde::{Deserialize, Serialize};
+
+/// Deserializes `PowerState` from either a bool (Lite-On: `true`/`false`)
+/// or a string (GB200: `"On"`/`"Off"`), normalizing to `Option<PowerState>`.
+fn deserialize_power_state<'de, D>(deserializer: D) -> Result<Option<PowerState>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct PowerStateVisitor;
+
+    impl<'de> de::Visitor<'de> for PowerStateVisitor {
+        type Value = Option<PowerState>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a bool, a PowerState string, or null")
+        }
+
+        fn visit_bool<E: de::Error>(self, v: bool) -> Result<Self::Value, E> {
+            Ok(Some(if v { PowerState::On } else { PowerState::Off }))
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+            serde_json::from_value::<PowerState>(serde_json::Value::String(v.to_string()))
+                .map(Some)
+                .map_err(de::Error::custom)
+        }
+
+        fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_some<D: serde::Deserializer<'de>>(
+            self,
+            deserializer: D,
+        ) -> Result<Self::Value, D::Error> {
+            deserializer.deserialize_any(PowerStateVisitor)
+        }
+    }
+
+    deserializer.deserialize_any(PowerStateVisitor)
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
@@ -114,6 +161,7 @@ pub struct InputRanges {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct PowerSupply {
+    pub id: Option<String>,
     pub firmware_version: Option<String>,
     // we need to track this metric
     pub last_power_output_watts: Option<f64>, // not in Supermicro or NVIDIA DPU
@@ -132,8 +180,8 @@ pub struct PowerSupply {
     pub power_capacity_watts: Option<f64>, // present but 'null' on Supermicro
     pub power_input_watts: Option<f64>,
     pub power_output_watts: Option<f64>,
-    #[serde(skip)] // gb200 has this as string and liteon has it as bool
-    pub power_state: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_power_state")]
+    pub power_state: Option<PowerState>,
     pub power_supply_type: Option<String>,
     pub serial_number: Option<String>,
     pub spare_part_number: Option<String>,

--- a/src/model/service_root.rs
+++ b/src/model/service_root.rs
@@ -106,7 +106,7 @@ impl ServiceRoot {
             }
             "nvidia" => match self.product.as_deref() {
                 Some("P3809") => RedfishVendor::P3809, // could be gh200 compute or nvswitch
-                Some("GB200 NVL") => RedfishVendor::NvidiaGBx00,
+                Some("GB200 NVL") | Some("GB BMC") => RedfishVendor::NvidiaGBx00,
                 _ => RedfishVendor::NvidiaDpu,
             },
             "wiwynn" => RedfishVendor::NvidiaGBx00,
@@ -127,12 +127,32 @@ impl ServiceRoot {
 
 #[cfg(test)]
 mod test {
-    use crate::model::service_root::RedfishVendor;
+    use crate::model::service_root::{RedfishVendor, ServiceRoot};
 
     #[test]
     fn test_supermicro_service_root() {
         let data = include_str!("testdata/supermicro_service_root.json");
         let result: super::ServiceRoot = serde_json::from_str(data).unwrap();
         assert_eq!(result.vendor().unwrap(), RedfishVendor::Supermicro);
+    }
+
+    #[test]
+    fn test_nvidia_gb_bmc_service_root() {
+        let result = ServiceRoot {
+            vendor: Some("NVIDIA".to_string()),
+            product: Some("GB BMC".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(result.vendor().unwrap(), RedfishVendor::NvidiaGBx00);
+    }
+
+    #[test]
+    fn test_nvidia_bluefield_service_root() {
+        let result = ServiceRoot {
+            vendor: Some("NVIDIA".to_string()),
+            product: Some("BlueField-3".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(result.vendor().unwrap(), RedfishVendor::NvidiaDpu);
     }
 }

--- a/src/model/service_root.rs
+++ b/src/model/service_root.rs
@@ -60,6 +60,7 @@ pub struct ServiceRoot {
 #[derive(Clone, Copy, Debug, PartialEq, Hash, Eq, Serialize, Deserialize)]
 pub enum RedfishVendor {
     Lenovo,
+    LenovoAMI,
     Dell,
     NvidiaDpu,
     Supermicro,
@@ -96,7 +97,13 @@ impl ServiceRoot {
             "ami" => RedfishVendor::AMI,
             "dell" => RedfishVendor::Dell,
             "hpe" => RedfishVendor::Hpe,
-            "lenovo" => RedfishVendor::Lenovo,
+            "lenovo" => {
+                if self.has_ami_bmc() {
+                    RedfishVendor::LenovoAMI
+                } else {
+                    RedfishVendor::Lenovo
+                }
+            }
             "nvidia" => match self.product.as_deref() {
                 Some("P3809") => RedfishVendor::P3809, // could be gh200 compute or nvswitch
                 Some("GB200 NVL") => RedfishVendor::NvidiaGBx00,

--- a/src/model/system.rs
+++ b/src/model/system.rs
@@ -78,6 +78,7 @@ pub enum PowerState {
     PoweringOn,
     Paused,
     Reset,
+    Unknown,
 }
 
 impl fmt::Display for PowerState {

--- a/src/network.rs
+++ b/src/network.rs
@@ -215,19 +215,19 @@ impl RedfishClientPool {
 
         let vendor = match vendor {
             Some(v) => v,
-            None => {
-                let Some(mut v) = service_root.vendor() else {
-                    return Err(RedfishError::MissingVendor);
-                };
-                if v == RedfishVendor::P3809 {
-                    if chassis.contains(&"MGX_NVSwitch_0".to_string()) {
-                        v = RedfishVendor::NvidiaGBSwitch;
-                    } else {
-                        v = RedfishVendor::NvidiaGH200;
-                    }
-                }
-                v
+            None => service_root.vendor().ok_or(RedfishError::MissingVendor)?,
+        };
+
+        // P3809 is a placeholder — always resolve it based on chassis
+        // contents, whether it was auto-detected or explicitly provided.
+        let vendor = if vendor == RedfishVendor::P3809 {
+            if chassis.contains(&"MGX_NVSwitch_0".to_string()) {
+                RedfishVendor::NvidiaGBSwitch
+            } else {
+                RedfishVendor::NvidiaGH200
             }
+        } else {
+            vendor
         };
 
         s.set_vendor(vendor).await

--- a/src/network.rs
+++ b/src/network.rs
@@ -149,14 +149,50 @@ impl RedfishClientPool {
             .await
     }
 
-    /// Creates a Redfish BMC client for a certain endpoint and adds custom headers to subsequent requests.
+    /// Creates a Redfish BMC client for a certain endpoint,
+    /// and adds custom headers to subsequent requests.
     ///
-    /// Creating the client will immediately start a HTTP requests
-    /// to set system_id, manager_id and vendor type.
-    /// `custom_headers` will be added to any headers used by vendor specific implementations or the http client.
+    /// Creating the client will immediately start HTTP requests
+    /// to set system_id, manager_id, and vendor type (the vendor
+    /// is auto-detected from the service root.
+    ///
+    /// `custom_headers` will be added to any headers used by vendor
+    /// specific implementations or the http client.
     pub async fn create_client_with_custom_headers(
         &self,
         endpoint: Endpoint,
+        custom_headers: Vec<(HeaderName, String)>,
+    ) -> Result<Box<dyn crate::Redfish>, RedfishError> {
+        self.create_client_impl(endpoint, None, custom_headers)
+            .await
+    }
+
+    /// Creates a Redfish BMC client for a certain endpoint using
+    /// the provided vendor instead of auto-detecting from the service
+    /// root. This is needed for BMCs (e.g. Lite-On power shelves) whose
+    /// service root does not expose vendor information, where we need
+    /// a client that uses vendor-specific logic.
+    pub async fn create_client_with_vendor(
+        &self,
+        endpoint: Endpoint,
+        vendor: RedfishVendor,
+        custom_headers: Vec<(HeaderName, String)>,
+    ) -> Result<Box<dyn crate::Redfish>, RedfishError> {
+        self.create_client_impl(endpoint, Some(vendor), custom_headers)
+            .await
+    }
+
+    // Creates a complete "client" that takes the endpoint, an optional
+    // vendor (which falls back to self-detection using the service root),
+    // and an optional set of custom headers.
+    //
+    // If there's ever a need to expose this as pub, it's entirely
+    // reasonable to do so (and rename it to something descriptive like
+    // create_complete_client).
+    async fn create_client_impl(
+        &self,
+        endpoint: Endpoint,
+        vendor: Option<RedfishVendor>,
         custom_headers: Vec<(HeaderName, String)>,
     ) -> Result<Box<dyn crate::Redfish>, RedfishError> {
         let client = RedfishHttpClient::new(self.http_client.clone(), endpoint, custom_headers);
@@ -172,22 +208,28 @@ impl RedfishClientPool {
         })?;
         let chassis = s.get_chassis_all().await?;
 
-        s.set_system_id(system_id)?;
         // call set_system_id always before calling set_vendor
+        s.set_system_id(system_id)?;
         s.set_manager_id(manager_id)?;
         s.set_service_root(service_root.clone())?;
 
-        let Some(mut vendor) = service_root.vendor() else {
-            return Err(RedfishError::MissingVendor);
-        };
-        if vendor == RedfishVendor::P3809 {
-            if chassis.contains(&"MGX_NVSwitch_0".to_string()) {
-                vendor = RedfishVendor::NvidiaGBSwitch;
-            } else {
-                vendor = RedfishVendor::NvidiaGH200;
+        let vendor = match vendor {
+            Some(v) => v,
+            None => {
+                let Some(mut v) = service_root.vendor() else {
+                    return Err(RedfishError::MissingVendor);
+                };
+                if v == RedfishVendor::P3809 {
+                    if chassis.contains(&"MGX_NVSwitch_0".to_string()) {
+                        v = RedfishVendor::NvidiaGBSwitch;
+                    } else {
+                        v = RedfishVendor::NvidiaGH200;
+                    }
+                }
+                v
             }
-        }
-        // returns the vendor specific object
+        };
+
         s.set_vendor(vendor).await
     }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -97,7 +97,7 @@ impl RedfishClientPoolBuilder {
 }
 
 /// The endpoint that the redfish client connects to
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)] // WARN: Do not derive Debug: Endpoint may contain credentials and must not be logged accidentally.
 pub struct Endpoint {
     /// Hostname or IP address of BMC
     pub host: String,

--- a/src/network.rs
+++ b/src/network.rs
@@ -20,8 +20,9 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-use std::{collections::HashMap, path::Path, time::Duration};
+use std::{borrow::Cow, collections::HashMap, path::Path, sync::OnceLock, time::Duration};
 
+use regex::Regex;
 use reqwest::{
     header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE, IF_MATCH},
     multipart::{Form, Part},
@@ -501,7 +502,7 @@ impl RedfishHttpClient {
                 let body_enc =
                     serde_json::to_string(b).map_err(|e| RedfishError::JsonSerializeError {
                         url,
-                        object_debug: format!("{b:?}"),
+                        object_debug: redact_sensitive_fields(&format!("{b:?}")).into_owned(),
                         source: e,
                     })?;
 
@@ -513,7 +514,7 @@ impl RedfishHttpClient {
             "TX {} {} {}",
             method,
             url,
-            body_enc.as_deref().unwrap_or_default()
+            RedactPasswords(body_enc.as_deref().unwrap_or_default())
         );
         let mut req_b = match *method {
             Method::GET => self.http_client.get(&url),
@@ -588,7 +589,7 @@ impl RedfishHttpClient {
                 url: url.clone(),
                 source: e,
             })?;
-        debug!("RX {status_code} {}", truncate(&response_body, 1500));
+        debug!("RX {status_code} {}", truncate(&redact_sensitive_fields(&response_body), 1500));
 
         if !status_code.is_success() {
             if status_code == StatusCode::FORBIDDEN && !response_body.is_empty() {
@@ -739,7 +740,7 @@ impl RedfishHttpClient {
                 url: url.to_string(),
                 source: e,
             })?;
-        debug!("RX {status_code} {}", truncate(&response_body, 1500));
+        debug!("RX {status_code} {}", truncate(&redact_sensitive_fields(&response_body), 1500));
 
         if !status_code.is_success() {
             return Err(RedfishError::HTTPErrorCode {
@@ -757,10 +758,149 @@ fn truncate(s: &str, len: usize) -> &str {
     &s[..len.min(s.len())]
 }
 
-#[test]
-fn test_truncate() {
-    assert_eq!(truncate("", 1500), "");
+/// Redacts known sensitive JSON fields for safe logging.
+///
+/// Operates directly on the serialised JSON string to avoid re-serialisation
+/// cost.  Returns `Cow::Borrowed(body)` unchanged when no sensitive field
+/// names are present (zero-copy fast path).  The actual bytes sent over the
+/// wire are **never** modified — only the string passed to this function is
+/// affected.
+///
+/// Redacted fields (exact, case-sensitive JSON key match):
+///   `Password`, `OldPassword`, `NewPassword`   — standard Redfish account/BIOS ops
+///   `CurrentUefiPassword`, `UefiPassword`       — NVIDIA DPU Bios/Settings PATCH
+///   `ImportBuffer`                              — Dell ImportSystemConfiguration XML blob
 
-    let big = "a".repeat(2000);
-    assert_eq!(truncate(&big, 1500).len(), 1500);
+/// A `Display` wrapper that redacts sensitive JSON fields on formatting.
+///
+/// Passing this to `tracing::debug!` defers evaluation until the macro decides the
+/// message will actually be emitted, so the regex never runs at non-debug log levels.
+struct RedactPasswords<'a>(&'a str);
+
+impl std::fmt::Display for RedactPasswords<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        redact_sensitive_fields(self.0).fmt(f)
+    }
+}
+
+fn redact_sensitive_fields(body: &str) -> Cow<'_, str> {
+    // Fast path: skip regex engine entirely when no sensitive key is present.
+    // "Password" covers all five password-style keys; "ImportBuffer" covers the
+    // Dell XML-in-JSON fallback path.
+    if !body.contains("Password") && !body.contains("ImportBuffer") {
+        return Cow::Borrowed(body);
+    }
+
+    static REDACT_RE: OnceLock<Regex> = OnceLock::new();
+    let re = REDACT_RE.get_or_init(|| {
+        // Matches a JSON key from the sensitive list followed by its quoted string value
+        // (including JSON escape sequences).  The key is captured in group 1 so it can
+        // be preserved verbatim in the replacement.
+        Regex::new(
+            r#""(Password|OldPassword|NewPassword|CurrentUefiPassword|UefiPassword|ImportBuffer)"\s*:\s*"(?:[^"\\]|\\.)*""#,
+        )
+        .expect("hardcoded redaction regex must be valid")
+    });
+
+    re.replace_all(body, r#""$1":"[REDACTED]""#)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_truncate() {
+        assert_eq!(truncate("", 1500), "");
+
+        let big = "a".repeat(2000);
+        assert_eq!(truncate(&big, 1500).len(), 1500);
+    }
+
+    #[test]
+    fn redact_password_field() {
+        let body = r#"{"UserName":"admin","Password":"s3cr3t!"}"#;
+        let redacted = redact_sensitive_fields(body);
+        assert!(!redacted.contains("s3cr3t!"), "plaintext password must not appear in log output");
+        assert!(redacted.contains("[REDACTED]"));
+        assert!(redacted.contains("UserName"), "non-sensitive fields must be preserved");
+    }
+
+    #[test]
+    fn redact_old_and_new_password_fields() {
+        let body =
+            r#"{"PasswordName":"AdministratorPassword","OldPassword":"old123","NewPassword":"new456"}"#;
+        let redacted = redact_sensitive_fields(body);
+        assert!(!redacted.contains("old123"), "OldPassword value must be redacted");
+        assert!(!redacted.contains("new456"), "NewPassword value must be redacted");
+        // PasswordName is a slot name, not a secret — must NOT be redacted.
+        assert!(redacted.contains("AdministratorPassword"), "PasswordName value must not be redacted");
+    }
+
+    #[test]
+    fn nvidia_dpu_uefi_password_fields_are_redacted() {
+        let body = r#"{"Attributes":{"CurrentUefiPassword":"old_secret","UefiPassword":"new_secret"}}"#;
+        let redacted = redact_sensitive_fields(body);
+        assert!(!redacted.contains("old_secret"), "CurrentUefiPassword value must be redacted");
+        assert!(!redacted.contains("new_secret"), "UefiPassword value must be redacted");
+        assert!(redacted.contains("CurrentUefiPassword"), "key name must be preserved");
+    }
+
+    #[test]
+    fn dell_import_buffer_xml_blob_is_redacted() {
+        let xml = r#"<SystemConfiguration><Component FQDD="BIOS.Setup.1-1"><Attribute Name="OldSetupPassword">my_uefi_pass</Attribute><Attribute Name="NewSetupPassword"></Attribute></Component></SystemConfiguration>"#;
+        let body = format!(
+            r#"{{"ShutdownType":"Forced","ShareParameters":{{"Target":"BIOS"}},"ImportBuffer":"{}"}}"#,
+            xml.replace('"', "\\\"")
+        );
+        let redacted = redact_sensitive_fields(&body);
+        assert!(!redacted.contains("my_uefi_pass"), "UEFI password in ImportBuffer XML must not appear in log output");
+        assert!(redacted.contains("[REDACTED]"));
+        assert!(redacted.contains("ShutdownType"), "non-sensitive fields must be preserved");
+    }
+
+    #[test]
+    fn non_sensitive_body_is_returned_borrowed() {
+        let body = r#"{"ResetType":"GracefulRestart"}"#;
+        match redact_sensitive_fields(body) {
+            Cow::Borrowed(s) => assert_eq!(s, body),
+            Cow::Owned(_) => panic!("non-sensitive body must take the zero-copy fast path"),
+        }
+    }
+
+    #[test]
+    fn empty_body_fast_path() {
+        match redact_sensitive_fields("") {
+            Cow::Borrowed(s) => assert_eq!(s, ""),
+            Cow::Owned(_) => panic!("empty string must take fast path"),
+        }
+    }
+
+    #[test]
+    fn wire_payload_is_unaffected() {
+        let body_enc = r#"{"UserName":"newuser","Password":"myP@ssw0rd"}"#.to_string();
+        let _log_safe = redact_sensitive_fields(&body_enc);
+        assert_eq!(body_enc, r#"{"UserName":"newuser","Password":"myP@ssw0rd"}"#,
+            "wire payload must never be modified");
+    }
+
+    #[test]
+    fn escaped_characters_in_password_are_redacted() {
+        let body = r#"{"Password":"p@ss\"w\\ord"}"#;
+        let redacted = redact_sensitive_fields(body);
+        assert!(!redacted.contains("p@ss"), "escaped password value must be redacted");
+        assert!(redacted.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn truncation_after_redaction_does_not_leak_partial_secret() {
+        let filler = "x".repeat(1490);
+        let secret = "supersecret_password_value";
+        let body = format!(r#"{{"Data":"{}","Password":"{}"}}"#, filler, secret);
+        assert!(body.len() > 1500, "body must exceed truncation limit for this test to be valid");
+
+        let redacted = redact_sensitive_fields(&body);
+        let logged = truncate(&redacted, 1500);
+        assert!(!logged.contains("supersecret"), "no part of the secret must appear after truncation");
+    }
 }

--- a/src/nvidia_dpu.rs
+++ b/src/nvidia_dpu.rs
@@ -879,6 +879,10 @@ impl Redfish for Bmc {
     async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
         self.s.set_utc_timezone().await
     }
+
+    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
+        self.s.disable_psu_hot_spare().await
+    }
 }
 
 impl Bmc {

--- a/src/nvidia_dpu.rs
+++ b/src/nvidia_dpu.rs
@@ -798,10 +798,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/nvidia_dpu.rs
+++ b/src/nvidia_dpu.rs
@@ -198,6 +198,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<(), RedfishError> {
         self.set_host_privilege_level(Restricted).await?;
         // we have found that only newer BMC fws support this action.
@@ -879,9 +883,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/nvidia_dpu.rs
+++ b/src/nvidia_dpu.rs
@@ -202,7 +202,7 @@ impl Redfish for Bmc {
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         self.set_host_privilege_level(Restricted).await?;
         // we have found that only newer BMC fws support this action.
         // Until we re-enable DPU BMC firmware updates in preingestion,
@@ -210,7 +210,8 @@ impl Redfish for Bmc {
         // BF3s that have a BMC that is too old.
         self.set_host_rshim(EnabledDisabled::Disabled).await?;
         self.set_internal_cpu_model(Embedded).await?;
-        self.boot_once(UefiHttp).await
+        self.boot_once(UefiHttp).await?;
+        Ok(None)
     }
 
     async fn machine_setup_status(

--- a/src/nvidia_gbswitch.rs
+++ b/src/nvidia_gbswitch.rs
@@ -821,12 +821,19 @@ impl Redfish for Bmc {
         ))
     }
 
-    async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
+    async fn set_host_privilege_level(
+        &self,
+        level: HostPrivilegeLevel,
+    ) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
 
     async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
         self.s.set_utc_timezone().await
+    }
+
+    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
+        self.s.disable_psu_hot_spare().await
     }
 }
 

--- a/src/nvidia_gbswitch.rs
+++ b/src/nvidia_gbswitch.rs
@@ -724,10 +724,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/nvidia_gbswitch.rs
+++ b/src/nvidia_gbswitch.rs
@@ -224,6 +224,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<(), RedfishError> {
         Ok(())
     }
@@ -831,9 +835,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/nvidia_gbswitch.rs
+++ b/src/nvidia_gbswitch.rs
@@ -228,8 +228,8 @@ impl Redfish for Bmc {
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
-    ) -> Result<(), RedfishError> {
-        Ok(())
+    ) -> Result<Option<String>, RedfishError> {
+        Ok(None)
     }
 
     async fn machine_setup_status(

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -1344,18 +1344,17 @@ impl UpdateParameters {
     pub fn new(component: ComponentType) -> UpdateParameters {
         let targets = match component {
             ComponentType::Unknown => None,
-            _ => Some(vec![match component {
-                ComponentType::BMC => "/redfish/v1/Chassis/BMC_0".to_string(),
-                ComponentType::EROTBMC => "/redfish/v1/Chassis/HGX_ERoT_BMC_0".to_string(),
-                ComponentType::EROTBIOS => {
-                    "/redfish/v1/UpdateService/FirmwareInventory/EROT_BIOS_0".to_string()
-                }
-                ComponentType::HGXBMC | ComponentType::UEFI => {
-                    "/redfish/v1/Chassis/HGX_Chassis_0".to_string()
-                }
-                _ => "unreachable".to_string(),
-            }]),
+            ComponentType::BMC => Some(vec![]),
+            ComponentType::EROTBMC => Some(vec!["/redfish/v1/Chassis/HGX_ERoT_BMC_0".to_string()]),
+            ComponentType::EROTBIOS => Some(vec![
+                "/redfish/v1/UpdateService/FirmwareInventory/EROT_BIOS_0".to_string(),
+            ]),
+            ComponentType::HGXBMC | ComponentType::UEFI => {
+                Some(vec!["/redfish/v1/Chassis/HGX_Chassis_0".to_string()])
+            }
+            _ => Some(vec!["unreachable".to_string()]),
         };
+
         UpdateParameters {
             targets,
             force_update: true,
@@ -1371,10 +1370,7 @@ mod tests {
     fn test_update_parameters_targets_all_variants() {
         let cases: Vec<(ComponentType, Option<Vec<String>>)> = vec![
             (ComponentType::Unknown, None),
-            (
-                ComponentType::BMC,
-                Some(vec!["/redfish/v1/Chassis/BMC_0".to_string()]),
-            ),
+            (ComponentType::BMC, Some(vec![])),
             (
                 ComponentType::EROTBMC,
                 Some(vec!["/redfish/v1/Chassis/HGX_ERoT_BMC_0".to_string()]),

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -1017,10 +1017,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -1096,12 +1096,19 @@ impl Redfish for Bmc {
         self.s.get_evidence(url).await
     }
 
-    async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
+    async fn set_host_privilege_level(
+        &self,
+        level: HostPrivilegeLevel,
+    ) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
 
     async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
         self.s.set_utc_timezone().await
+    }
+
+    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
+        self.s.disable_psu_hot_spare().await
     }
 }
 

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -468,6 +468,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<(), RedfishError> {
         self.disable_secure_boot().await?;
 
@@ -1106,9 +1110,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -472,7 +472,7 @@ impl Redfish for Bmc {
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         self.disable_secure_boot().await?;
 
         let bios_attrs = self.machine_setup_attrs().await?;
@@ -480,7 +480,11 @@ impl Redfish for Bmc {
         attrs.extend(bios_attrs);
         let body = HashMap::from([("Attributes", attrs)]);
         let url = format!("Systems/{}/Bios/Settings", self.s.system_id());
-        self.s.client.patch(&url, body).await.map(|_status_code| ())
+        self.s
+            .client
+            .patch(&url, body)
+            .await
+            .map(|_status_code| None)
     }
 
     async fn machine_setup_status(

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -684,10 +684,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -781,12 +781,19 @@ impl Redfish for Bmc {
         ))
     }
 
-    async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
+    async fn set_host_privilege_level(
+        &self,
+        level: HostPrivilegeLevel,
+    ) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
 
     async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
         self.s.set_utc_timezone().await
+    }
+
+    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
+        self.s.disable_psu_hot_spare().await
     }
 }
 

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -189,6 +189,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<(), RedfishError> {
         self.disable_secure_boot().await?;
         self.boot_once(UefiHttp).await
@@ -791,9 +795,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -193,9 +193,10 @@ impl Redfish for Bmc {
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         self.disable_secure_boot().await?;
-        self.boot_once(UefiHttp).await
+        self.boot_once(UefiHttp).await?;
+        Ok(None)
     }
 
     async fn machine_setup_status(

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -948,10 +948,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -31,15 +31,38 @@ use tracing::{debug, error, info, warn};
 use version_compare::Version;
 
 use crate::{
-    BiosProfileType, Boot, BootOptions, Collection, EnabledDisabled::{self, Disabled, Enabled}, JobState, MachineSetupDiff, MachineSetupStatus, ODataId, PCIeDevice, PowerState, Redfish, RedfishError, Resource, RoleId, Status, StatusInternal, SystemPowerControl, model::{
-        BootOption, ComputerSystem, EnableDisable, Manager, ManagerResetType, account_service::ManagerAccount, boot::{BootSourceOverrideEnabled, BootSourceOverrideTarget}, certificate::Certificate, chassis::{Assembly, Chassis, NetworkAdapter}, component_integrity::ComponentIntegrities, network_device_function::NetworkDeviceFunction, oem::{
+    model::{
+        account_service::ManagerAccount,
+        boot::{BootSourceOverrideEnabled, BootSourceOverrideTarget},
+        certificate::Certificate,
+        chassis::{Assembly, Chassis, NetworkAdapter},
+        component_integrity::ComponentIntegrities,
+        network_device_function::NetworkDeviceFunction,
+        oem::{
             nvidia_dpu::{HostPrivilegeLevel, NicMode},
             nvidia_viking::{
                 BootDevices::{self},
                 *,
             },
-        }, power::Power, resource::IsResource, secure_boot::SecureBoot, sel::{LogEntry, LogEntryCollection}, sensor::{GPUSensors, Sensor}, service_root::{RedfishVendor, ServiceRoot}, software_inventory::SoftwareInventory, storage::Drives, task::Task, thermal::Thermal, update_service::{ComponentType, TransferProtocolType, UpdateService}
-    }, standard::RedfishStandard
+        },
+        power::Power,
+        resource::IsResource,
+        secure_boot::SecureBoot,
+        sel::{LogEntry, LogEntryCollection},
+        sensor::{GPUSensors, Sensor},
+        service_root::{RedfishVendor, ServiceRoot},
+        software_inventory::SoftwareInventory,
+        storage::Drives,
+        task::Task,
+        thermal::Thermal,
+        update_service::{ComponentType, TransferProtocolType, UpdateService},
+        BootOption, ComputerSystem, EnableDisable, Manager, ManagerResetType,
+    },
+    standard::RedfishStandard,
+    BiosProfileType, Boot, BootOptions, Collection,
+    EnabledDisabled::{self, Disabled, Enabled},
+    JobState, MachineSetupDiff, MachineSetupStatus, ODataId, PCIeDevice, PowerState, Redfish,
+    RedfishError, Resource, RoleId, Status, StatusInternal, SystemPowerControl,
 };
 
 const UEFI_PASSWORD_NAME: &str = "AdminPassword";
@@ -979,12 +1002,19 @@ impl Redfish for Bmc {
         self.s.get_evidence(url).await
     }
 
-    async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
+    async fn set_host_privilege_level(
+        &self,
+        level: HostPrivilegeLevel,
+    ) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
 
     async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
         self.s.set_utc_timezone().await
+    }
+
+    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
+        self.s.disable_psu_hot_spare().await
     }
 }
 

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -300,15 +300,20 @@ impl Redfish for Bmc {
                 StatusInternal::Partial,
             ),
             (Some(kcs), Some(rf)) => {
-                let status = if kcs == *KCS_INTERFACE_DISABLE_DENY_ALL
-                /*&& bios.redfish_enable == Disabled */
-                {
+                let is_locked =
+                    kcs == KCS_INTERFACE_DISABLE_DENY_ALL || kcs == KCS_INTERFACE_DISABLE_DISABLED;
+                let is_unlocked = (kcs == KCS_INTERFACE_DISABLE_ALLOW_ALL
+                    || kcs == KCS_INTERFACE_DISABLE_ENABLED)
+                    && rf == EnabledDisabled::Enabled;
+
+                let status = if is_locked {
                     StatusInternal::Enabled
-                } else if kcs == KCS_INTERFACE_DISABLE_ALLOW_ALL && rf == EnabledDisabled::Enabled {
+                } else if is_unlocked {
                     StatusInternal::Disabled
                 } else {
                     StatusInternal::Partial
                 };
+
                 (
                     format!("ipmi_kcs_disable={}, redfish_enable={}.", kcs, rf),
                     status,
@@ -1015,7 +1020,6 @@ impl Redfish for Bmc {
     async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
         self.s.set_utc_timezone().await
     }
-
 }
 
 impl Bmc {
@@ -1179,6 +1183,22 @@ impl Bmc {
         )))
     }
 
+    /// Returns the KCS values (lockdown_enabled, lockdown_disabled) based on
+    /// what the current firmware accepts. Newer firmware uses "Enabled"/"Disabled"
+    /// instead of "Deny All"/"Allow All".
+    fn kcs_lockdown_values(&self, current_kcs: &Option<String>) -> (&'static str, &'static str) {
+        match current_kcs.as_deref() {
+            Some(KCS_INTERFACE_DISABLE_ENABLED | KCS_INTERFACE_DISABLE_DISABLED) => (
+                KCS_INTERFACE_DISABLE_DISABLED,
+                KCS_INTERFACE_DISABLE_ENABLED,
+            ),
+            _ => (
+                KCS_INTERFACE_DISABLE_DENY_ALL,
+                KCS_INTERFACE_DISABLE_ALLOW_ALL,
+            ),
+        }
+    }
+
     async fn enable_lockdown(&self) -> Result<(), RedfishError> {
         // assuming that the viking bmc does not modify the suffixes
         self.check_firmware_version(
@@ -1194,8 +1214,11 @@ impl Bmc {
         )
         .await?;
 
+        let bios = self.get_bios().await?;
+        let (kcs_disable_deny, _) =
+            self.kcs_lockdown_values(&bios.attributes.kcs_interface_disable);
         let lockdown_attrs = BiosAttributes {
-            kcs_interface_disable: DEFAULT_KCS_INTERFACE_DISABLE.to_string().into(),
+            kcs_interface_disable: kcs_disable_deny.to_string().into(),
             redfish_enable: Disabled.into(), // todo: this should be disabled for the virtual usb nic, not yet implemented by dgx team
             ..Default::default()
         };
@@ -1206,8 +1229,11 @@ impl Bmc {
     }
 
     async fn disable_lockdown(&self) -> Result<(), RedfishError> {
+        let bios = self.get_bios().await?;
+        let (_, kcs_disable_allow) =
+            self.kcs_lockdown_values(&bios.attributes.kcs_interface_disable);
         let lockdown_attrs = BiosAttributes {
-            kcs_interface_disable: KCS_INTERFACE_DISABLE_ALLOW_ALL.to_string().into(),
+            kcs_interface_disable: kcs_disable_allow.to_string().into(),
             redfish_enable: Enabled.into(),
             ..Default::default()
         };

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -218,6 +218,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<(), RedfishError> {
         self.set_bios_attributes().await
     }
@@ -1012,9 +1016,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -222,8 +222,9 @@ impl Redfish for Bmc {
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
-    ) -> Result<(), RedfishError> {
-        self.set_bios_attributes().await
+    ) -> Result<Option<String>, RedfishError> {
+        self.set_bios_attributes().await?;
+        Ok(None)
     }
 
     async fn machine_setup_status(
@@ -1020,6 +1021,8 @@ impl Redfish for Bmc {
     async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
         self.s.set_utc_timezone().await
     }
+
+
 }
 
 impl Bmc {

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -941,13 +941,25 @@ impl Redfish for RedfishStandard {
         Ok(body)
     }
 
-    async fn set_host_privilege_level(&self, _level: HostPrivilegeLevel) -> Result<(), RedfishError> {
-        Err(RedfishError::NotSupported("set_host_privilege_level".to_string()))
+    async fn set_host_privilege_level(
+        &self,
+        _level: HostPrivilegeLevel,
+    ) -> Result<(), RedfishError> {
+        Err(RedfishError::NotSupported(
+            "set_host_privilege_level".to_string(),
+        ))
     }
 
     async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
         // No-op for non-Dell vendors
         Ok(())
+    }
+
+    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
+        // PSU Hot Spare is Dell-specific; other vendors handle PSU redundancy differently
+        Err(RedfishError::NotSupported(
+            "disable_psu_hot_spare".to_string(),
+        ))
     }
 }
 

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -873,7 +873,6 @@ impl Redfish for RedfishStandard {
         &self,
         _controller_id: &str,
         _volume_name: &str,
-        _raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         Err(RedfishError::NotSupported(
             "create_storage_volume".to_string(),

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -265,6 +265,10 @@ impl Redfish for RedfishStandard {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<(), RedfishError> {
         Err(RedfishError::NotSupported("machine_setup".to_string()))
     }
@@ -957,12 +961,6 @@ impl Redfish for RedfishStandard {
         Ok(())
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        // PSU Hot Spare is Dell-specific; other vendors handle PSU redundancy differently
-        Err(RedfishError::NotSupported(
-            "disable_psu_hot_spare".to_string(),
-        ))
-    }
 }
 
 impl RedfishStandard {

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -128,7 +128,10 @@ impl Redfish for RedfishStandard {
         data.insert("Password", new_pass);
         let service_root = self.get_service_root().await?;
         // AMI BMC requires If-Match header for PATCH requests
-        if matches!(service_root.vendor(), Some(RedfishVendor::AMI)) || service_root.has_ami_bmc() {
+        if matches!(
+            service_root.vendor(),
+            Some(RedfishVendor::AMI | RedfishVendor::LenovoAMI)
+        ) {
             self.client.patch_with_if_match(&url, &data).await
         } else {
             self.client
@@ -1013,14 +1016,8 @@ impl RedfishStandard {
             }
             RedfishVendor::Dell => Ok(Box::new(crate::dell::Bmc::new(self.clone())?)),
             RedfishVendor::Hpe => Ok(Box::new(crate::hpe::Bmc::new(self.clone())?)),
-            RedfishVendor::Lenovo => {
-                // Check if this Lenovo has an AMI-based BMC
-                if self.service_root.has_ami_bmc() {
-                    Ok(Box::new(crate::ami::Bmc::new(self.clone())?))
-                } else {
-                    Ok(Box::new(crate::lenovo::Bmc::new(self.clone())?))
-                }
-            }
+            RedfishVendor::Lenovo => Ok(Box::new(crate::lenovo::Bmc::new(self.clone())?)),
+            RedfishVendor::LenovoAMI => Ok(Box::new(crate::ami::Bmc::new(self.clone())?)),
             RedfishVendor::NvidiaDpu => Ok(Box::new(crate::nvidia_dpu::Bmc::new(self.clone())?)),
             RedfishVendor::NvidiaGBx00 => {
                 Ok(Box::new(crate::nvidia_gbx00::Bmc::new(self.clone())?))

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -269,7 +269,7 @@ impl Redfish for RedfishStandard {
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         Err(RedfishError::NotSupported("machine_setup".to_string()))
     }
 

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -632,17 +632,7 @@ impl Redfish for RedfishStandard {
     }
 
     async fn get_service_root(&self) -> Result<ServiceRoot, RedfishError> {
-        let (_status_code, mut body): (StatusCode, ServiceRoot) = self.client.get("").await?;
-        // fix lite-on power shelf bmc behavior
-        if body.vendor.is_none() {
-            let chassis_all = self.get_chassis_all().await?;
-            if chassis_all.contains(&"powershelf".to_string()) {
-                let chassis = self.get_chassis("powershelf").await?;
-                if let Some(x) = chassis.manufacturer {
-                    body.vendor = Some(x);
-                }
-            }
-        }
+        let (_status_code, body) = self.client.get("").await?;
         Ok(body)
     }
 

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -27,12 +27,33 @@ use serde::Serialize;
 use tokio::fs::File;
 
 use crate::{
-    BiosProfileType, Boot, BootOptions, Collection, EnabledDisabled, JobState, MachineSetupDiff, MachineSetupStatus, ODataId, PCIeDevice, PowerState, Redfish, RedfishError, Resource, RoleId, Status, StatusInternal, SystemPowerControl, model::{
-        BootOption, ComputerSystem, EnableDisable, InvalidValueError, Manager, account_service::ManagerAccount, boot, certificate::Certificate, chassis::{Assembly, Chassis, NetworkAdapter}, component_integrity::ComponentIntegrities, network_device_function::NetworkDeviceFunction, oem::{
+    model::{
+        account_service::ManagerAccount,
+        boot,
+        certificate::Certificate,
+        chassis::{Assembly, Chassis, NetworkAdapter},
+        component_integrity::ComponentIntegrities,
+        network_device_function::NetworkDeviceFunction,
+        oem::{
             nvidia_dpu::{HostPrivilegeLevel, NicMode},
             supermicro::{self, FixedBootOrder},
-        }, power::Power, secure_boot::SecureBoot, sel::LogEntry, sensor::GPUSensors, service_root::{RedfishVendor, ServiceRoot}, software_inventory::SoftwareInventory, storage::Drives, task::Task, thermal::Thermal, update_service::{ComponentType, TransferProtocolType, UpdateService}
-    }, standard::RedfishStandard
+        },
+        power::Power,
+        secure_boot::SecureBoot,
+        sel::LogEntry,
+        sensor::GPUSensors,
+        service_root::{RedfishVendor, ServiceRoot},
+        software_inventory::SoftwareInventory,
+        storage::Drives,
+        task::Task,
+        thermal::Thermal,
+        update_service::{ComponentType, TransferProtocolType, UpdateService},
+        BootOption, ComputerSystem, EnableDisable, InvalidValueError, Manager,
+    },
+    standard::RedfishStandard,
+    BiosProfileType, Boot, BootOptions, Collection, EnabledDisabled, JobState, MachineSetupDiff,
+    MachineSetupStatus, ODataId, PCIeDevice, PowerState, Redfish, RedfishError, Resource, RoleId,
+    Status, StatusInternal, SystemPowerControl,
 };
 
 const MELLANOX_UEFI_HTTP_IPV4: &str = "UEFI HTTP IPv4 Mellanox Network Adapter";
@@ -907,12 +928,19 @@ impl Redfish for Bmc {
         self.s.get_evidence(url).await
     }
 
-    async fn set_host_privilege_level(&self, level: HostPrivilegeLevel) -> Result<(), RedfishError> {
+    async fn set_host_privilege_level(
+        &self,
+        level: HostPrivilegeLevel,
+    ) -> Result<(), RedfishError> {
         self.s.set_host_privilege_level(level).await
     }
 
     async fn set_utc_timezone(&self) -> Result<(), RedfishError> {
         self.s.set_utc_timezone().await
+    }
+
+    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
+        self.s.disable_psu_hot_spare().await
     }
 }
 

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -874,10 +874,9 @@ impl Redfish for Bmc {
         &self,
         controller_id: &str,
         volume_name: &str,
-        raid_type: &str,
     ) -> Result<Option<String>, RedfishError> {
         self.s
-            .create_storage_volume(controller_id, volume_name, raid_type)
+            .create_storage_volume(controller_id, volume_name)
             .await
     }
 

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -196,6 +196,10 @@ impl Redfish for Bmc {
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
         _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
     ) -> Result<(), RedfishError> {
         self.setup_serial_console().await?;
 
@@ -938,9 +942,6 @@ impl Redfish for Bmc {
         self.s.set_utc_timezone().await
     }
 
-    async fn disable_psu_hot_spare(&self) -> Result<(), RedfishError> {
-        self.s.disable_psu_hot_spare().await
-    }
 }
 
 impl Bmc {

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -200,7 +200,7 @@ impl Redfish for Bmc {
             RedfishVendor,
             HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
         >,
-    ) -> Result<(), RedfishError> {
+    ) -> Result<Option<String>, RedfishError> {
         self.setup_serial_console().await?;
 
         let bios_attrs = self.machine_setup_attrs().await?;
@@ -208,7 +208,11 @@ impl Redfish for Bmc {
         attrs.extend(bios_attrs);
         let body = HashMap::from([("Attributes", attrs)]);
         let url = format!("Systems/{}/Bios", self.s.system_id());
-        self.s.client.patch(&url, body).await.map(|_status_code| ())
+        self.s
+            .client
+            .patch(&url, body)
+            .await
+            .map(|_status_code| None)
     }
 
     async fn machine_setup_status(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -637,6 +637,7 @@ async fn resource_tests(redfish: &dyn Redfish) -> Result<(), anyhow::Error> {
 
     let chassis_id = match vendor {
         RedfishVendor::Lenovo | RedfishVendor::Supermicro | RedfishVendor::Hpe => "1",
+        RedfishVendor::LenovoAMI => "Self",
         RedfishVendor::AMI => "DGX",
         RedfishVendor::NvidiaDpu => "Card1",
         RedfishVendor::Dell => "System.Embedded.1",


### PR DESCRIPTION
fix: do not try to anonymously query the chassis subsystem as part of querying the service root

We have logic in site explorer to special case powershelves.